### PR TITLE
Update JoiningOpenBeta.mdx

### DIFF
--- a/src/content/docs/open-beta/JoiningOpenBeta.mdx
+++ b/src/content/docs/open-beta/JoiningOpenBeta.mdx
@@ -34,7 +34,7 @@ There are 2 ways to select the Development Channel:
 Download Linux build [here](https://github.com/PixiEditor/PixiEditor-development-channel/releases/latest)
 
 1. Run PixiEditor (Make sure it's not from Steam or Microsoft Store, it must be downloaded from [pixieditor.net](https://pixieditor.net).
-2. Open File -> Settings -> General.
-3. Choose "Development" from the "Channel" dropdown menu.
+2. Open File -> Settings -> Updates.
+3. Choose "Development" from the "Update stream" dropdown menu.
 
 ![Development Channel](channel.png)


### PR DESCRIPTION
The given instructions to access dev channel were outdated back to when it was an option under general instead of a separate update tab